### PR TITLE
Fix: PresentationControls snap type definition error #954

### DIFF
--- a/src/web/PresentationControls.tsx
+++ b/src/web/PresentationControls.tsx
@@ -3,9 +3,10 @@ import { MathUtils } from 'three'
 import { useThree } from '@react-three/fiber'
 import { a, useSpring } from '@react-spring/three'
 import { useGesture } from '@use-gesture/react'
+import { SpringConfig } from '@react-spring/core'
 
 type Props = {
-  snap?: boolean
+  snap?: Boolean | SpringConfig
   global?: boolean
   cursor?: boolean
   speed?: number


### PR DESCRIPTION
### Why

resolves #954 `PresentationControls` `snap`'s type can be `SpringConfig`

### What

Appended `@react-spring/core`'s SpringConfig to the `snap` type.

#### Before: 
```
snap?: Boolean
```

#### After: 
```
snap?: Boolean | SpringConfig
```

### Checklist
- [x] Ready to be merged
